### PR TITLE
Fixed youtube link

### DIFF
--- a/docs/3-user-guides/yoroi-troubleshooting.md
+++ b/docs/3-user-guides/yoroi-troubleshooting.md
@@ -3,7 +3,7 @@ sidebar_position: 6
 ---
 
 # Yoroi troubleshooting
-<!-- import YouTube from 'react-youtube'; -->
+import YouTube from 'react-youtube';
 
 ## Yoroi syncing issues
 


### PR DESCRIPTION
Needed to uncomment "import YouTube from 'react-youtube';" as it was commented out for local build